### PR TITLE
.github: Add issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -1,0 +1,54 @@
+name: 🐞 Bug report
+description: Create a report to help us improve
+
+labels: [bug, needs-triage]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please fill out the sections below to help everyone identify and fix the bug. If you have a general idea or question then please use the [discussions](https://github.com/orgs/X11Libre/discussions).
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe your issue
+      placeholder: When I did X then Y happened.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Start ...
+        2. Do this
+        3. Do that
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+      placeholder: I expected this to happen.
+  - type: textarea
+    id: environment
+    attributes:
+      label: Additional Information
+      description: |
+        Additional information you want to provide such as logs, system info, environment, screenshots, etc.
+      placeholder: |
+        Add any other context about the bug here.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Extra fields
+      options:
+        - label: I have checked the existing [issues](https://github.com/X11Libre/xf86-video-vmware/issues)
+          required: true
+        - label: I have read the [Contributing Guidelines](https://github.com/X11Libre/xserver/blob/master/CONTRIBUTING.md)
+          required: true
+        - label: I'd like to work on this issue
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting this issue! We will get back to you as soon as possible.

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -1,0 +1,49 @@
+name: ✨ Feature request
+description: Suggest a feature for this software
+labels: [enhancement, needs-triage]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please fill out the sections below to properly describe the new software feature you are suggesting. If you have a general idea or question then please use the [discussions](https://github.com/orgs/X11Libre/discussions).
+  - type: textarea
+    id: description
+    attributes:
+      label: "Describe the feature"
+      placeholder: A thing in X that allows to do Y.
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: "It should be done because"
+      placeholder: Doing Y is needed for Z.
+    validations:
+      required: true
+  - type: textarea
+    id: alternative
+    attributes:
+      label: "What are the alternatives?"
+      placeholder: We could do A or B instead.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Additional information you want to provide such as references to related issues or protocols, the implications on existing use cases, etc.
+      placeholder: |
+        Add any other context about the feature request here.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Extra fields
+      options:
+        - label: I have checked the existing [issues](https://github.com/X11Libre/xf86-video-vmware/issues)
+          required: true
+        - label: I have read the [Contributing Guidelines](https://github.com/X11Libre/xserver/blob/master/CONTRIBUTING.md)
+          required: true
+        - label: I'd like to work on this issue
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your suggestion! Let's see together if it can be done.

--- a/.github/ISSUE_TEMPLATE/03-code-cleanup.yml
+++ b/.github/ISSUE_TEMPLATE/03-code-cleanup.yml
@@ -1,0 +1,49 @@
+name: 🔧 Code cleanup
+description: Level up the source code
+labels: [code-cleanup, needs-triage]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please fill out the sections below to properly describe the code cleanup you are suggesting. If you have a general idea or question then please use the [discussions](https://github.com/orgs/X11Libre/discussions).
+  - type: textarea
+    id: description
+    attributes:
+      label: "Describe the cleanup"
+      placeholder: C in X needs to be changed into D.
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: "It should be done because"
+      placeholder: Having D is needed for E.
+    validations:
+      required: true
+  - type: textarea
+    id: alternative
+    attributes:
+      label: "What are the alternatives?"
+      placeholder: We could do A or B instead.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Additional information you want to provide such as implications on existing code, how to ensure API/ABI stability, which tests are needed or to be run, related issues, etc.
+      placeholder: |
+        Add any other context about the cleanup here.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Extra fields
+      options:
+        - label: I have checked the existing [issues](https://github.com/X11Libre/xf86-video-vmware/issues)
+          required: true
+        - label: I have read the [Contributing Guidelines](https://github.com/X11Libre/xserver/blob/master/CONTRIBUTING.md)
+          required: true
+        - label: I'd like to work on this issue
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for looking at the source code! Let's see together how it can be improved.

--- a/.github/ISSUE_TEMPLATE/04-doc-update.yml
+++ b/.github/ISSUE_TEMPLATE/04-doc-update.yml
@@ -1,0 +1,38 @@
+name: 🔖 Documentation update
+description: Make your mark for better documentation
+
+labels: [documentation, needs-triage]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please fill out the sections below to help others understand our software. If you have a general idea or question then please use the [discussions](https://github.com/orgs/X11Libre/discussions).
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the update
+      placeholder: These things need to be better documented.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Additional Information
+      description: Additional information you want to provide such as tickets related to changes in the software, affected files, screenshots, etc.
+      placeholder: |
+        Add any other context about the update here.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Extra fields
+      options:
+        - label: I have checked the existing [issues](https://github.com/X11Libre/xf86-video-vmware/issues)
+          required: true
+        - label: I have read the [Contributing Guidelines](https://github.com/X11Libre/xserver/blob/master/CONTRIBUTING.md)
+          required: true
+        - label: I'd like to work on this issue
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for requesting this update! We will get back to you as soon as possible.

--- a/.github/ISSUE_TEMPLATE/05-org-task.yml
+++ b/.github/ISSUE_TEMPLATE/05-org-task.yml
@@ -1,0 +1,43 @@
+name: ✅ Organizational task
+description: Create a task for project organization
+
+labels: [needs-triage, organization]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please fill out the sections below to get organizational things done. If you have a general idea or question then please use the [discussions](https://github.com/orgs/X11Libre/discussions).
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the task
+      placeholder: These things need to be done.
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: "It should be done because"
+      placeholder: Doing Y is needed for Z.
+  - type: textarea
+    id: environment
+    attributes:
+      label: Additional Information
+      description: Additional information you want to provide such as the context for bigger tasks, the implicatons on existing workflows, related issues, etc.
+      placeholder: |
+        Add any other context about the task here.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Extra fields
+      options:
+        - label: I have checked the existing [issues](https://github.com/X11Libre/xf86-video-vmware/issues)
+          required: true
+        - label: I have read the [Contributing Guidelines](https://github.com/X11Libre/xserver/blob/master/CONTRIBUTING.md)
+          required: true
+        - label: I'd like to work on this issue
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for adding this task! We will get back to you as soon as possible.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: XLibre Community Support
+    url: https://github.com/orgs/X11Libre/discussions
+    about: Please ask and answer questions here.
+  - name: Mailing List
+    url: https://www.freelists.org/list/xlibre
+    about: You can join the discussions on our mailing list.


### PR DESCRIPTION
Add the following forms for issue creation:

* Bug report
* Feature request
* Code change
* Documentation update
* Organizational task

* add issue type selection page on "New Issue" call
* mention Github Discussions and the mailing list where appropriate

Part-of: X11Libre/misc#156
Signed-off-by: callmetango <callmetango@users.noreply.github.com>
