### PR TITLE
vmwarexinerama: fix missing include of extinit.h

### DIFF
--- a/src/vmwarexinerama.c
+++ b/src/vmwarexinerama.c
@@ -36,6 +36,9 @@
 #include "config.h"
 #endif
 
+#include <xorg-server.h>
+
+#include "extinit.h"
 #include "dixstruct.h"
 #include "extnsionst.h"
 #include <X11/X.h>


### PR DESCRIPTION
Don't realy it being included indirectly from somewhere else by accident.