### PR TITLE
Fix variable in drv_block_handler and KMS/3D support check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,6 +70,9 @@ XORG_DRIVER_CHECK_EXT(DPMSExtension, xextproto)
 XORG_DRIVER_CHECK_EXT(XINERAMA, xineramaproto)
 XORG_DRIVER_CHECK_EXT(XV, videoproto)
 
+# Enable vmwgfx by default
+BUILD_VMWGFX=yes
+
 # Obtain compiler/linker options for the driver dependencies
 PKG_CHECK_MODULES(XORG, [xorg-server >= 25.0.0 xproto fontsproto $REQUIRED_MODULES])
 
@@ -79,9 +82,8 @@ PKG_CHECK_MODULES([PCIACCESS], [pciaccess >= 0.8.0])
 
 AC_SUBST([moduledir])
 
-if test x$BUILD_VMWGFX = xyes; then
-	PKG_CHECK_MODULES([LIBDRM], [libdrm],[],[BUILD_VMWGFX=no])
-fi
+PKG_CHECK_MODULES([LIBDRM], [libdrm],[],[BUILD_VMWGFX=no])
+
 if test x$BUILD_VMWGFX = xyes; then
 #
 # Early versions of mesa 10 forgot to bump the XA major version number in

--- a/vmwgfx/vmwgfx_driver.c
+++ b/vmwgfx/vmwgfx_driver.c
@@ -791,12 +791,12 @@ void xorg_flush(ScreenPtr pScreen)
     free(pixmaps);
 }
 
-static void drv_block_handler(ScreenPtr pScrn, void *pTimeout)
+static void drv_block_handler(ScreenPtr pScreen, void *pTimeout)
 {
     modesettingPtr ms = modesettingPTR(xf86ScreenToScrn(pScreen));
 
     vmwgfx_swap(ms, pScreen, BlockHandler);
-    pScreen->BlockHandler(arg, pTimeout);
+    pScreen->BlockHandler(pScreen, pTimeout);
     vmwgfx_swap(ms, pScreen, BlockHandler);
 
     if (vmwgfx_is_hosted(ms->hdriver))


### PR DESCRIPTION
This seems to fix https://github.com/X11Libre/xf86-video-vmware/issues/18 in master branch, making it compile with KMS and 3D support.

I'm still learning how PRs work, but I made this to show how that issue was fixed for me, so please see if this is ok for real :)