### PR TITLE
replace deprecated min/max macros by MIN/MAX

### DIFF
--- a/src/common_compat.h
+++ b/src/common_compat.h
@@ -9,4 +9,12 @@
 #define DRM_MODE_FB_DIRTY_MAX_CLIPS 256
 #endif
 
+#ifndef MIN
+#define MIN(a,b) ((a)<(b)?(a):(b))
+#endif
+
+#ifndef MAX
+#define MAX(a,b) ((a)>(b)?(a):(b))
+#endif
+
 #endif

--- a/src/vmware.c
+++ b/src/vmware.c
@@ -808,8 +808,8 @@ VMWAREModeInit(ScrnInfoPtr pScrn, DisplayModePtr mode, Bool rebuildPixmap)
     if (pVMWARE->vmwareCapability & SVGA_CAP_PITCHLOCK)
 	vmwareWriteReg(pVMWARE, SVGA_REG_PITCHLOCK, 0);
     vmwareReg->svga_reg_enable = 1;
-    vmwareReg->svga_reg_width = max(mode->HDisplay, pScrn->virtualX);
-    vmwareReg->svga_reg_height = max(mode->VDisplay, pScrn->virtualY);
+    vmwareReg->svga_reg_width = MAX(mode->HDisplay, pScrn->virtualX);
+    vmwareReg->svga_reg_height = MAX(mode->VDisplay, pScrn->virtualY);
     vmwareReg->svga_reg_bits_per_pixel = pVMWARE->bitsPerPixel;
 
     vgaHWProtect(pScrn, TRUE);

--- a/vmwgfx/vmwgfx_dri2.c
+++ b/vmwgfx/vmwgfx_dri2.c
@@ -45,6 +45,7 @@
 #include "wsbm_util.h"
 #include <unistd.h>
 #include "vmwgfx_hosted.h"
+#include "common_compat.h"
 
 #define VMWGFX_FD_PATH_LEN 80
 
@@ -422,7 +423,7 @@ xorg_dri2_init(ScreenPtr pScreen)
 	minor = 0;
     }
 
-    dri2info.version = min(DRI2INFOREC_VERSION, 3);
+    dri2info.version = MIN(DRI2INFOREC_VERSION, 3);
     dri2info.fd = ms->fd;
     dri2info.driverName = "vmwgfx";
 

--- a/vmwgfx/vmwgfx_driver.c
+++ b/vmwgfx/vmwgfx_driver.c
@@ -646,7 +646,7 @@ vmwgfx_scanout_update(int drm_fd, int fb_id, RegionPtr dirty)
 {
     BoxPtr clips = REGION_RECTS(dirty);
     unsigned int num_clips = REGION_NUM_RECTS(dirty);
-    unsigned int alloc_clips = min(num_clips, DRM_MODE_FB_DIRTY_MAX_CLIPS);
+    unsigned int alloc_clips = MIN(num_clips, DRM_MODE_FB_DIRTY_MAX_CLIPS);
     drmModeClip *rects, *r;
     int i, ret;
 
@@ -660,7 +660,7 @@ vmwgfx_scanout_update(int drm_fd, int fb_id, RegionPtr dirty)
     }
 
     while (num_clips > 0) {
-	unsigned int cur_clips = min(num_clips, DRM_MODE_FB_DIRTY_MAX_CLIPS);
+	unsigned int cur_clips = MIN(num_clips, DRM_MODE_FB_DIRTY_MAX_CLIPS);
 
 	memset(rects, 0, alloc_clips * sizeof(*rects));
 

--- a/vmwgfx/vmwgfx_drmi.c
+++ b/vmwgfx/vmwgfx_drmi.c
@@ -79,7 +79,7 @@ vmwgfx_present_readback(int drm_fd, uint32_t fb_id, RegionPtr region)
 {
     BoxPtr clips = REGION_RECTS(region);
     unsigned int num_clips = REGION_NUM_RECTS(region);
-    unsigned int alloc_clips = min(num_clips, DRM_MODE_FB_DIRTY_MAX_CLIPS);
+    unsigned int alloc_clips = MIN(num_clips, DRM_MODE_FB_DIRTY_MAX_CLIPS);
     struct drm_vmw_fence_rep rep;
     struct drm_vmw_present_readback_arg arg;
     int ret;
@@ -97,7 +97,7 @@ vmwgfx_present_readback(int drm_fd, uint32_t fb_id, RegionPtr region)
     }
 
     while (num_clips > 0) {
-	unsigned int cur_clips = min(num_clips, DRM_MODE_FB_DIRTY_MAX_CLIPS);
+	unsigned int cur_clips = MIN(num_clips, DRM_MODE_FB_DIRTY_MAX_CLIPS);
 
 	memset(&arg, 0, sizeof(arg));
 	memset(&rep, 0, sizeof(rep));
@@ -149,7 +149,7 @@ vmwgfx_present(int drm_fd, uint32_t fb_id, unsigned int dst_x,
 {
     BoxPtr clips = REGION_RECTS(region);
     unsigned int num_clips = REGION_NUM_RECTS(region);
-    unsigned int alloc_clips = min(num_clips, DRM_MODE_FB_DIRTY_MAX_CLIPS);
+    unsigned int alloc_clips = MIN(num_clips, DRM_MODE_FB_DIRTY_MAX_CLIPS);
     struct drm_vmw_present_arg arg;
     unsigned int i;
     struct drm_vmw_rect *rects, *r;
@@ -166,7 +166,7 @@ vmwgfx_present(int drm_fd, uint32_t fb_id, unsigned int dst_x,
     }
 
     while (num_clips > 0) {
-	unsigned int cur_clips = min(num_clips, DRM_MODE_FB_DIRTY_MAX_CLIPS);
+	unsigned int cur_clips = MIN(num_clips, DRM_MODE_FB_DIRTY_MAX_CLIPS);
 
 	memset(&arg, 0, sizeof(arg));
 	memset(rects, 0, alloc_clips * sizeof(*rects));
@@ -330,7 +330,7 @@ vmwgfx_dma(int host_x, int host_y,
 	unsigned int size;
 	unsigned int cur_clips;
 
-	cur_clips = min(num_clips, max_clips);
+	cur_clips = MIN(num_clips, max_clips);
 	size = sizeof(*cmd) + (cur_clips - 1) * sizeof(cmd->cb) +
 	    sizeof(*suffix);
 

--- a/vmwgfx/vmwgfx_layout.c
+++ b/vmwgfx/vmwgfx_layout.c
@@ -152,10 +152,10 @@ vmwgfx_layout_from_kms(ScrnInfoPtr pScrn)
 	vmwgfx_output_origin(output, &box->x, &box->y);
 	box->width = output->probed_modes->HDisplay;
 	box->height = output->probed_modes->VDisplay;
-	min_x = min(min_x, box->x);
-	min_y = min(min_y, box->y);
-	max_x = max(max_x, box->x + box->width);
-	max_y = max(max_y, box->y + box->height);
+	min_x = MIN(min_x, box->x);
+	min_y = MIN(min_y, box->y);
+	max_x = MAX(max_x, box->x + box->width);
+	max_y = MAX(max_y, box->y + box->height);
     }
 
     layout->root_width = max_x;


### PR DESCRIPTION
These xserver's public macros are being deprecated in favor of private ones. The drivers need to declare them locally.

Reference: https://github.com/X11Libre/xserver/pull/1490

Fixes: https://github.com/X11Libre/xf86-video-vmware/issues/22